### PR TITLE
Fix missing changelog entries

### DIFF
--- a/static/changelog.html
+++ b/static/changelog.html
@@ -30,7 +30,7 @@
       <div id="changelog-entries">
         <div class="changelog-entry">
           <a href="changelog_0_13_2.html"><h2>Version 0.13.2</h2></a>
-          <p class="changelog-date">Mar 25, 2024</p>
+          <p class="changelog-date">Mar 24, 2024</p>
         </div>
         <div class="changelog-entry">
           <a href="changelog_0_13_1.html"><h2>Version 0.13.1</h2></a>

--- a/static/changelog_0_13_2.html
+++ b/static/changelog_0_13_2.html
@@ -27,7 +27,7 @@
     <main class="content-width">
       <div class="title">
         <h1>Alacritty Version 0.13.2 Release</h1>
-        <h4>Mar 25, 2024</h4>
+        <h4>Mar 24, 2024</h4>
       </div>
 
       <div id="github-release">
@@ -38,7 +38,7 @@
       </div>
 
       <div class="changelog-content">
-        <h2><a name="Added" href="#Added">Added</a></h2><ul><li>Default `Home`/`End` bindings in Vi mode mapped to `First`/`Last` respectively</li></ul><h2><a name="Fixed" href="#Fixed">Fixed</a></h2><ul><li>CLI env variables clearing configuration file variables</li><li>Vi inline search/semantic selection expanding across newlines</li><li>C0 and C1 codes being emitted in associated text when using kitty keyboard</li><li>Occasional hang on startup with some Wayland compositors</li><li>Missing key for `NumpadDecimal` in key bindings</li><li>Scrolling content upwards moving lines into history when it shouldn't</li><li>Sticky keys not working sometimes on X11</li><li>Modifiers occasionally getting desynced on X11</li><li>Autokey no longer working with alacritty on X11</li><li>Freeze when moving window between monitors on Xfwm</li><li>Mouse cursor not changing on Wayland when cursor theme uses legacy cursor icon names</li><li>Config keys are available under proper names</li><li>Build failure when compiling with x11 feature on NetBSD</li><li>Hint `Select` action selecting the entire line for URL escapes</li></ul><h2><a name="Changed" href="#Changed">Changed</a></h2><ul><li>No unused-key warnings will be emitted for OS-specific config keys</li><li>Use built-in font for sextant symbols from `U+1FB00` to `U+1FB3B`</li><li>Kitty encoding is not used anymore for uncommon keys unless the protocol enabled</li></ul>
+        <h2><a name="Added" href="#Added">Added</a></h2><ul><li>Default `Home`/`End` bindings in Vi mode mapped to `First`/`Last` respectively</li></ul><h2><a name="Fixed" href="#Fixed">Fixed</a></h2><ul><li>CLI env variables clearing configuration file variables</li><li>Vi inline search/semantic selection expanding across newlines</li><li>C0 and C1 codes being emitted in associated text when using kitty keyboard</li><li>Occasional hang on startup with some Wayland compositors</li><li>Missing key for `NumpadDecimal` in key bindings</li><li>Scrolling content upwards moving lines into history when it shouldn't</li><li>Sticky keys not working sometimes on X11</li><li>Modifiers occasionally getting desynced on X11</li><li>Autokey no longer working with alacritty on X11</li><li>Freeze when moving window between monitors on Xfwm</li><li>Mouse cursor not changing on Wayland when cursor theme uses legacy cursor icon names</li><li>Config keys are available under proper names</li><li>Build failure when compiling with x11 feature on NetBSD</li><li>Hint `Select` action selecting the entire line for URL escapes</li><li>Kitty encoding used for regular keys when they don't carry text</li></ul><h2><a name="Changed" href="#Changed">Changed</a></h2><ul><li>No unused-key warnings will be emitted for OS-specific config keys</li><li>Use built-in font for sextant symbols from `U+1FB00` to `U+1FB3B`</li><li>Kitty encoding is not used anymore for uncommon keys unless the protocol enabled</li></ul>
       </div>
     </main>
   </body>


### PR DESCRIPTION
This adds a missing changelog entry to the 0.13.2 release.

The date is also changed to match the official release date, since the website update was technically done a day late.