### PR TITLE
Fix 0.13.2 markdown formatting

### DIFF
--- a/static/changelog_0_13_2.html
+++ b/static/changelog_0_13_2.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
-  <head>
+
+<head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <title>Alacritty</title>
@@ -8,38 +9,66 @@
     <link rel="stylesheet" href="changelog.css" type="text/css" media="all">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css">
     <link rel="icon" href="alacritty-simple.svg">
-  </head>
-  <body>
+</head>
+
+<body>
     <header>
-      <div id="header-content" class="content-width">
-        <a id="logo" href="index.html">
-          <img id="logo-img" src="alacritty-simple.svg" alt="Alacritty Logo"/>
-          lacritty
-        </a>
-        <nav>
-          <a href="config-alacritty.html">Configuration</a>
-          <a href="changelog.html">Changelog</a>
-          <a href="https://github.com/alacritty/alacritty" target="_blank"><i class="fa fa-github"></i></a>
-        </nav>
-      </div>
+        <div id="header-content" class="content-width">
+            <a id="logo" href="index.html">
+                <img id="logo-img" src="alacritty-simple.svg" alt="Alacritty Logo" /> lacritty
+            </a>
+            <nav>
+                <a href="config-alacritty.html">Configuration</a>
+                <a href="changelog.html">Changelog</a>
+                <a href="https://github.com/alacritty/alacritty" target="_blank"><i class="fa fa-github"></i></a>
+            </nav>
+        </div>
     </header>
 
     <main class="content-width">
-      <div class="title">
-        <h1>Alacritty Version 0.13.2 Release</h1>
-        <h4>Mar 24, 2024</h4>
-      </div>
+        <div class="title">
+            <h1>Alacritty Version 0.13.2 Release</h1>
+            <h4>Mar 24, 2024</h4>
+        </div>
 
-      <div id="github-release">
-        Prebuilt binaries can be found in the
-        <a href="https://github.com/alacritty/alacritty/releases/tag/v0.13.2">
+        <div id="github-release">
+            Prebuilt binaries can be found in the
+            <a href="https://github.com/alacritty/alacritty/releases/tag/v0.13.2">
           GitHub release.
         </a>
-      </div>
+        </div>
 
-      <div class="changelog-content">
-        <h2><a name="Added" href="#Added">Added</a></h2><ul><li>Default `Home`/`End` bindings in Vi mode mapped to `First`/`Last` respectively</li></ul><h2><a name="Fixed" href="#Fixed">Fixed</a></h2><ul><li>CLI env variables clearing configuration file variables</li><li>Vi inline search/semantic selection expanding across newlines</li><li>C0 and C1 codes being emitted in associated text when using kitty keyboard</li><li>Occasional hang on startup with some Wayland compositors</li><li>Missing key for `NumpadDecimal` in key bindings</li><li>Scrolling content upwards moving lines into history when it shouldn't</li><li>Sticky keys not working sometimes on X11</li><li>Modifiers occasionally getting desynced on X11</li><li>Autokey no longer working with alacritty on X11</li><li>Freeze when moving window between monitors on Xfwm</li><li>Mouse cursor not changing on Wayland when cursor theme uses legacy cursor icon names</li><li>Config keys are available under proper names</li><li>Build failure when compiling with x11 feature on NetBSD</li><li>Hint `Select` action selecting the entire line for URL escapes</li><li>Kitty encoding used for regular keys when they don't carry text</li></ul><h2><a name="Changed" href="#Changed">Changed</a></h2><ul><li>No unused-key warnings will be emitted for OS-specific config keys</li><li>Use built-in font for sextant symbols from `U+1FB00` to `U+1FB3B`</li><li>Kitty encoding is not used anymore for uncommon keys unless the protocol enabled</li></ul>
-      </div>
+        <div class="changelog-content">
+            <h2><a name="Added" href="#Added">Added</a></h2>
+            <ul>
+                <li>Default <kbd>Home</kbd>/<kbd>End</kbd> bindings in Vi mode mapped to <code>First</code>/<code>Last</code> respectively</li>
+            </ul>
+            <h2><a name="Fixed" href="#Fixed">Fixed</a></h2>
+            <ul>
+                <li>CLI env variables clearing configuration file variables</li>
+                <li>Vi inline search/semantic selection expanding across newlines</li>
+                <li>C0 and C1 codes being emitted in associated text when using kitty keyboard</li>
+                <li>Occasional hang on startup with some Wayland compositors</li>
+                <li>Missing key for <kbd>NumpadDecimal</kbd> in key bindings</li>
+                <li>Scrolling content upwards moving lines into history when it shouldn't</li>
+                <li>Sticky keys not working sometimes on X11</li>
+                <li>Modifiers occasionally getting desynced on X11</li>
+                <li>Autokey no longer working with alacritty on X11</li>
+                <li>Freeze when moving window between monitors on Xfwm</li>
+                <li>Mouse cursor not changing on Wayland when cursor theme uses legacy cursor icon names</li>
+                <li>Config keys are available under proper names</li>
+                <li>Build failure when compiling with x11 feature on NetBSD</li>
+                <li>Hint <code>Select</code> action selecting the entire line for URL escapes</li>
+                <li>Kitty encoding used for regular keys when they don't carry text</li>
+            </ul>
+            <h2><a name="Changed" href="#Changed">Changed</a></h2>
+            <ul>
+                <li>No unused-key warnings will be emitted for OS-specific config keys</li>
+                <li>Use built-in font for sextant symbols from <code>U+1FB00</code> to <code>U+1FB3B</code></li>
+                <li>Kitty encoding is not used anymore for uncommon keys unless the protocol enabled</li>
+            </ul>
+        </div>
     </main>
-  </body>
+</body>
+
 </html>


### PR DESCRIPTION
Noticed another thing I forgot about the 0.13.2 release changelog.