### PR TITLE
Fix typo in config-alacritty.html

### DIFF
--- a/static/config-alacritty.html
+++ b/static/config-alacritty.html
@@ -114,7 +114,7 @@
       number of columns must be at least <em>2</em>, while using a value
       of <em>0</em> for columns and lines will fall back to the window
       manager's recommended size</p>
-      <p>Default: { column = <em>0</em>, lines = <em>0</em> }</p>
+      <p>Default: { columns = <em>0</em>, lines = <em>0</em> }</p>
       </blockquote>
       <p><strong>position</strong> = <em>"None"</em> | { x =
       <em>&lt;integer&gt;</em>, y = <em>&lt;integer&gt;</em> }</p>


### PR DESCRIPTION
The key in `window.dimensions` is `columns`, not `column`.

https://github.com/alacritty/alacritty/blob/f5e02862ffdcc579264ce85f11aed96732b257ff/alacritty/src/config/window.rs#L90