### PR TITLE
Fix Windows config path

### DIFF
--- a/static/config-alacritty.html
+++ b/static/config-alacritty.html
@@ -43,7 +43,7 @@
       </ol>
       <p>On Windows, the config file will be looked for in:</p>
       <ol type="1">
-      <li><p>`%APPDATA%alacrittyalacritty.toml`</p></li>
+      <li><p>`%APPDATA%\alacritty\alacritty.toml`</p></li>
       </ol>
       <h1 id="general"><a href="#general">GENERAL</a></h1>
       <p>This section documents the root level of the configuration


### PR DESCRIPTION
Closes #32.

---

There's likely something wrong with the automatic generation, but for now I've just fixed it manually.