### PR TITLE
Update config-alacritty.html for 0.14.0

### DIFF
--- a/static/releases/0.14.0/config-alacritty.html
+++ b/static/releases/0.14.0/config-alacritty.html
@@ -736,7 +736,7 @@
       </blockquote>
       <p>Example:</p>
       <blockquote>
-      <p><strong>[shell]</strong><br>
+      <p><strong>[terminal.shell]</strong><br>
       program = <em>"/bin/zsh"</em><br>
       args = [<em>"-l"</em>]</p>
       </blockquote>


### PR DESCRIPTION
The present configuration example creates the following warning:

    [WARN] Config warning: shell has been deprecated; use terminal.shell instead
    Use `alacritty migrate` to automatically resolve it
    See log at (…)

I'm no TOML expert, don't know if remaining section needs updating as well.